### PR TITLE
fixed a bug where date preposition "on" became "true" on talk detail page

### DIFF
--- a/_data/lang.yml
+++ b/_data/lang.yml
@@ -7,7 +7,7 @@ en:
     by: by
     for: for
     in: in
-    on_: on
+    on_: "on"
   overview: Overview
   more_information: More Information
   live:


### PR DESCRIPTION
Thank you very much for creating the elegantly crafted template.
In using this template, I stumbled upon a bug where date preposition "on" becomes 'true" on talk detail page when multi-day mode is enabled (as in the attached screenshot).
As I investigated the issue, I found the culprit to be YAML's treatment of `on` as true (boolean literal), instead of string literal.
This patch fixes the issue by quoting `on` in `lang.yml`.

<img width="1128" alt="Screen Shot 2022-10-10 at 10 34 49" src="https://user-images.githubusercontent.com/354132/194789199-bb27f8e2-1b12-4951-af72-87f66bdb1932.png">
