### PR TITLE
Fix talk time formatting when minutes is a single digit

### DIFF
--- a/_includes/partials/show_talk_time.html
+++ b/_includes/partials/show_talk_time.html
@@ -11,7 +11,7 @@
     {%- unless talk_day_hide -%} {{ day_abbr }}, {% endunless -%}
     {%- assign talk_day_hide = false -%}
   {% endif -%}
-  {{- talk_start_hour -}}:{%- if talk_start_min == 0 -%}0{%- endif -%}{{- talk_start_min -}}
+  {{- talk_start_hour -}}:{%- if talk_start_min < 10 -%}0{%- endif -%}{{- talk_start_min -}}
 </a>
 
 {%- assign talk_time_styleclass = "" -%}


### PR DESCRIPTION
Thanks for creating a great theme! ([our usage](https://www.unicode.org/events/utw/)) 

We noticed a bug when the number of minutes is a single digit. This is a hacky workaround that ought to fix the problem.

Of course, I feel required to say that the ideal solution would be to use ICU -- the industry standard i18n library -- to handle [formatting datetimes](https://unicode-org.github.io/icu/userguide/format_parse/datetime/) and many other such operations. And if you're in an international context, it's indispensable. :-) I don't know too much about Ruby and Jekyll, and whether there is an ICU wrapper there.

FYI @sffc