### PR TITLE
Exclude `vendor` directory from being processed

### DIFF
--- a/_config.example.yml
+++ b/_config.example.yml
@@ -14,6 +14,7 @@ sass:
 
 # Additional exclude from processing
 exclude:
+  - vendor
   - .github/
   - README.md
   - LICENSE.md


### PR DESCRIPTION
This avoids incredibly confusing issues like https://github.com/jekyll/jekyll/issues/2938, https://github.com/jekyll/jekyll/issues/5267, https://ben.balter.com/jekyll-auth/troubleshooting/, etc., when building on GitHub Actions following your instructions.