### PR TITLE
Set program initial day based on local TZ, not UTC

### DIFF
--- a/_includes/js/program.js
+++ b/_includes/js/program.js
@@ -16,13 +16,21 @@ window.conference.program = (() => {
             // Switch to day if today
             else {
                 let today = new Date();
-                today.setHours(0,0,0,0);
+                let localDateString = today.getFullYear() + "-";
+                let month = today.getMonth();
+                month = month + 1;
+                if (month < 10) {
+                    localDateString = localDateString + '0';
+                }
+                localDateString = localDateString + month + "-";
+                let dayOfMonth = today.getDate();
+                if (dayOfMonth < 10) {
+                    localDateString = localDateString + "0";
+                }
+                localDateString = localDateString + dayOfMonth;
 
                 $('a[data-toggle="tab"]').each(function () {
-                    let d = new Date($(this).data('date'));
-                    d.setHours(0,0,0,0);
-
-                    if (today.getTime() === d.getTime()) {
+                    if ($(this).data('date') === localDateString) {
                         $(this).tab('show');
                         updateHash(this.hash);
                     }


### PR DESCRIPTION
Problem: When using this theme over here in the `America/Los_Angeles` time zone (GMT-8 / GMT-9), for a 2-day event, during the event on the first day, the program page defaulted to showing the 2nd day. And on the 2nd day of the event, the program went back to showing the 1st day.

Tracing the problem down, it looks like the JS Date API doesn't provide good functions for converting between UTC and local time zones well. The code in `program.js` was taking the user's days' strings, which are representing local time zone days, instantiating a `Date` in JS (which only creates a UTC time zone date), and then compares the day part to the user's JS runtime's current Date instance's day part.

This issue probably doesn't manifest for people whose time zone is close enough to GMT / UTC.

Solution:

Treat the user provided day string from the program as the day in the local time zone. Construct an analogous string in the user's JS runtime and then do string comparison. This works around JS's lack of time zone support in the Date API to compare 2 "local dates" (dates that are not representing an absolute time pinned to the UTC time zone).