### PR TITLE
README: Fix version tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,15 +127,15 @@ To install:
    bundle
    ```
 
-4. Add `remote_theme: "DigitaleGesellschaft/jekyll-theme-conference@4.0.1"` to your `_config.yml` file. Remove any other `theme:` or `remote_theme:` entry.
+4. Add `remote_theme: "DigitaleGesellschaft/jekyll-theme-conference@v4.0.1"` to your `_config.yml` file. Remove any other `theme:` or `remote_theme:` entry.
 
    ```yaml
-   remote_theme: "DigitaleGesellschaft/jekyll-theme-conference@4.0.1"
+   remote_theme: "DigitaleGesellschaft/jekyll-theme-conference@v4.0.1"
    ```
 
 5. Continue with the [_Setup_](#setup) section below to customize the theme and add content for your conference.
 
-To update the theme, change the version tag in the `remote_theme` value (e.g., `@4.0.0` to `@v4.1.0`).
+To update the theme, change the version tag in the `remote_theme` value (e.g., `@v4.0.0` to `@v4.1.0`).
 
 
 ## Setup


### PR DESCRIPTION
It looks like all version tags need to be prefixed with "v". Without that, the installation fails with a 404 error as in [0] (which was also missing a "v"). I've tested this change locally and am now able to install the v4.0.1 version.

[0] - https://github.com/DigitaleGesellschaft/jekyll-theme-conference/issues/18